### PR TITLE
#44 Fix permission error in update-json workflow

### DIFF
--- a/.github/workflows/update-json.yml
+++ b/.github/workflows/update-json.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   update-json:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Check out source repository
         uses: actions/checkout@v4


### PR DESCRIPTION
GitHub Actionsのupdate-jsonワークフローがパーミッションエラーで落ちてしまうのを修正した。[peter-evans/create-pull-requestのドキュメント](https://github.com/peter-evans/create-pull-request#token)に従ってpermissionsを付与し、レポジトリの設定から「Allow GitHub Actions to create and approve pull requests」をオンにした。

参考文献
- [Breaking change with v6: Error: GitHub Actions is not permitted to create or approve pull requests. · Issue #2767 · peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request/issues/2767)
- [The process '/usr/bin/git' failed with exit code 128 · Issue #690 · peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request/issues/690)