### PR TITLE
#98 Remove slot column in GPU table

### DIFF
--- a/db/Gpu.ts
+++ b/db/Gpu.ts
@@ -33,9 +33,6 @@ export class Gpu {
   bus_interface!: string | null;
 
   @Column("text", { nullable: true })
-  slot!: string | null;
-
-  @Column("text", { nullable: true })
   standard!: string | null;
 
   @Column("text", { nullable: true })


### PR DESCRIPTION
`db/Gpu.ts`のGpuエンティティからslotカラムを削除し、`no such column: gpu.slot`のエラーを解消した。preview環境でGPU検索できるようになったことを確認済み。